### PR TITLE
fix: server crash due to mailer service code bug

### DIFF
--- a/apps/server/src/modules/auth/supertokens/supertokens.config.ts
+++ b/apps/server/src/modules/auth/supertokens/supertokens.config.ts
@@ -47,7 +47,7 @@ export const recipeList = (
               logEmail(logger, email, urlWithLinkCode);
 
               try {
-                mailerService.sendMail({
+                await mailerService.sendMail({
                   to: email,
                   subject: 'Login for Tegon',
                   template: 'loginUser',


### PR DESCRIPTION
## Issue Context
When we run server locally and click on "get magic ling" will get following error which leads to server crash. 
![tagon-error](https://github.com/user-attachments/assets/353ee4ed-23b7-49dd-93ac-0e5e1a8056d5)


## fix
`await` was not added `mailerService.sendMail(` and due to that error was not caught.