### PR TITLE
fix: dueDate and labelids issues

### DIFF
--- a/apps/server/src/modules/issues/issues.service.ts
+++ b/apps/server/src/modules/issues/issues.service.ts
@@ -227,6 +227,9 @@ export default class IssuesService {
       ...otherIssueData
     } = issueData;
 
+    console.log('Received issue data:', issueData);
+    console.log('Due date from issue data:', issueData.dueDate);
+
     // Find the current issue
     const currentIssue = await this.prisma.issue.findUnique({
       where: { id: issueParams.issueId },
@@ -285,6 +288,8 @@ export default class IssuesService {
       }),
     };
 
+    console.log('Updated issue data:', updatedIssueData);
+
     // Update the issue in the database
     const updatedIssue = await this.prisma.issue.update({
       where: {
@@ -296,6 +301,8 @@ export default class IssuesService {
         team: true,
       },
     });
+
+    console.log('Updated issue:', updatedIssue);
 
     this.logger.info({
       message: `Issue with ID ${issueParams.issueId} updated successfully`,

--- a/apps/webapp/src/modules/issues/components/issue-metadata/due-date/due-date.tsx
+++ b/apps/webapp/src/modules/issues/components/issue-metadata/due-date/due-date.tsx
@@ -11,19 +11,24 @@ import { format } from 'date-fns';
 import React from 'react';
 
 interface DueDateProps {
-  dueDate?: Date | string;
-  dueDateChange: (date: Date) => void;
+  dueDate?: Date | string | null;
+  dueDateChange: (date: Date | null) => void;
 }
 
 export function DueDate({
   dueDateChange,
   dueDate: initialDueDate,
 }: DueDateProps) {
-  const [dueDate, setDueDate] = React.useState<Date>(
-    initialDueDate ? new Date(initialDueDate) : undefined,
+  const [dueDate, setDueDate] = React.useState<Date | null>(
+    initialDueDate ? new Date(initialDueDate) : null
   );
 
-  const onDateChange = (date: Date) => {
+  React.useEffect(() => {
+    setDueDate(initialDueDate ? new Date(initialDueDate) : null);
+  }, [initialDueDate]);
+
+  const onDateChange = (date: Date | null) => {
+    console.log('DueDate: onDateChange called with:', date);
     setDueDate(date);
     dueDateChange(date);
   };

--- a/apps/webapp/src/modules/issues/single-issue/right-side/right-side.tsx
+++ b/apps/webapp/src/modules/issues/single-issue/right-side/right-side.tsx
@@ -23,7 +23,19 @@ import { IssueRelatedProperties } from './issue-related-properties';
 
 export const RightSide = observer(() => {
   const issue = useIssueData();
-  const { mutate: updateIssue } = useUpdateIssueMutation({});
+  const { mutate: updateIssue } = useUpdateIssueMutation({
+    onMutate: (variables) => {
+      console.log('UpdateIssueMutation: Starting mutation with variables:', variables);
+    },
+    onSuccess: (data, variables) => {
+      console.log('UpdateIssueMutation: Success. Updated data:', data);
+      console.log('UpdateIssueMutation: Variables used:', variables);
+    },
+    onError: (error, variables) => {
+      console.error('UpdateIssueMutation: Error updating issue:', error);
+      console.error('UpdateIssueMutation: Variables used:', variables);
+    },
+  });
   const currentTeam = useCurrentTeam();
   const statusChange = (stateId: string) => {
     updateIssue({ id: issue.id, stateId, teamId: issue.teamId });
@@ -45,9 +57,26 @@ export const RightSide = observer(() => {
     });
   };
 
-  const dueDateChange = (dueDate: Date) => {
-    updateIssue({ id: issue.id, dueDate, teamId: issue.teamId });
+  const dueDateChange = (date: Date | null) => {
+    console.log('RightSide: Updating due date to:', date);
+    const isoDate = date ? date.toISOString() : null;
+    console.log('RightSide: Converted ISO date:', isoDate);
+    updateIssue(
+      { id: issue.id, dueDate: isoDate, teamId: issue.teamId },
+      {
+        onSuccess: (data) => {
+          console.log('RightSide: updateIssue succeeded with data:', data);
+        },
+        onError: (error) => {
+          console.error('RightSide: updateIssue failed with error:', error);
+        },
+      }
+    );
   };
+
+  React.useEffect(() => {
+    console.log('RightSide: Issue data changed:', issue);
+  }, [issue]);
 
   return (
     <>

--- a/apps/webapp/src/store/issues/store.ts
+++ b/apps/webapp/src/store/issues/store.ts
@@ -23,9 +23,16 @@ export const IssuesStore: IAnyStateTreeNode = types
 
     const updateIssue = (updateProps: Partial<IssueType>, id: string) => {
       const issue = self.issuesMap.get(id);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const issueJson = (issue as any).toJSON();
-      self.issuesMap.set(id, { ...issueJson, ...updateProps });
+      if (issue) {
+        const updatedIssue = {
+          ...issue.toJSON(),
+          ...updateProps,
+          labelIds: updateProps.labelIds
+            ? [...updateProps.labelIds]
+            : issue.labelIds,
+        };
+        self.issuesMap.set(id, Issue.create(updatedIssue));
+      }
     };
 
     const deleteById = (id: string) => {


### PR DESCRIPTION
Errors:
1. Type mismatch error:
- The dueDate field in the Issue model was expecting a string or null, but it was receiving a Date object.
2. MobX-State-Tree conversion error:
- Even when passing an ISO string, MobX-State-Tree was unable to assign the value to the dueDate field.
3. State tree conflict with labelIds:
- When updating the issue, there was an attempt to add an object to the state tree that was already part of another state tree, specifically with the labelIds field.


Fixes:

- Updated the Issue model definition to explicitly handle dueDate as a nullable string.
- Modified the dueDateChange function to convert Date objects to ISO strings before updating the issue.
- Updated the update function in update-issue.tsx to properly handle both dueDate and labelIds when preparing update data.
- Adjusted the updateIssue action in the store to create a new labelIds array, preventing state tree conflicts.
- Implemented additional error handling and logging throughout the update process for better debugging.
- Ensured that null values for dueDate are properly handled when clearing the date.
- Addressed potential issues with existing labelIds to prevent conflicts when updating an issue.
- These changes collectively resolve type mismatches, state tree conflicts, and improve the overall robustness of the due date update functionality.