### PR TITLE
Fix: Local Setup - Remove stale /index.css import

### DIFF
--- a/apps/webapp/src/pages/_app.tsx
+++ b/apps/webapp/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import './global.css';
-import '@tegonhq/ui/index.css';
 import '@tegonhq/ui/global.css';
 import type { NextComponentType } from 'next';
 import type { AppContext, AppInitialProps, AppLayoutProps } from 'next/app';


### PR DESCRIPTION
This clears the failure to compile error during local setup:

```
client.js:26 ./src/pages/_app.tsx
Module not found: Can't resolve '@tegonhq/ui/index.css'

https://nextjs.org/docs/messages/module-not-found
```

There is no `index.css` file that exists in /ui/src/