### PR TITLE
Run existing Prisma migrations on "pnpm dev" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "dev-website": "dotenv -- turbo run dev --filter=website",
-    "dev": "dotenv -- turbo run dev --parallel --filter=!website",
+    "dev": "dotenv -- turbo run migrate dev --parallel --filter=!website",
     "build": "dotenv -- turbo run build",
     "lint": "turbo run lint",
     "generate": "dotenv -- turbo run generate",


### PR DESCRIPTION
This prevents [Issue 294](https://github.com/tegonhq/tegon/issues/294) during local setup

Alternatively, the need to explicitly run `migrate` could be added as a separate step to the [Local Setup Instructions](https://docs.tegon.ai/oss/local-setup) ?