### PR TITLE
Fix the broken link to the repository issues page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Please note that by contributing to this project, you're expected to follow Tego
 
 ## Reporting Issues
 
-If you encounter any issues or have suggestions for improvements, please feel free to (create an issue on Tegon's GitHub repository)[https://github.com/tegonhq/tegon/issues/new]. When reporting issues, please provide as much detail as possible to help in understanding and addressing the problem effectively.
+If you encounter any issues or have suggestions for improvements, please feel free to [create an issue on Tegon's GitHub repository](https://github.com/tegonhq/tegon/issues/new). When reporting issues, please provide as much detail as possible to help in understanding and addressing the problem effectively.
 
 ---
 


### PR DESCRIPTION
I have fixed the incorrect syntax for Markdown links in the `CONTRIBUTING.md` file. Let me know of any changes. Thank you.