### PR TITLE
gitignore the .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 docker/.env
 node_modules
 .turbo
+.idea
 
 out
 docker-compose.prod.yaml


### PR DESCRIPTION
I have added the `.idea/` folder to the `.gitignore` file because it's not necessary to share as part of the project. This folder is specific to each developer's IDE configuration and setup. Please let me know if you have any changes or suggestions. Thank you!