### PR TITLE
Fix: Handle possibly undefined workspaceRes causing error on onboarding screen

### DIFF
--- a/apps/webapp/src/common/wrappers/user-data-wrapper.tsx
+++ b/apps/webapp/src/common/wrappers/user-data-wrapper.tsx
@@ -39,7 +39,7 @@ export function UserDataWrapper(props: Props): React.ReactElement {
       (work) => work.slug === workspaceSlug,
     );
 
-    if (workspaceRes.status === 'SUSPENDED') {
+    if (workspaceRes?.status === 'SUSPENDED') {
       return (
         <div className="flex flex-col h-[100vh] w-[100vw] items-center justify-center gap-2">
           <Logo width={100} height={100} /> Your account is suspended


### PR DESCRIPTION
### Situation
In the welcome page, when logging in for the first time, there may be no workspaces available.

This can result in `workspaceRes` being `undefined` due to the `find` method not matching any workspaces. 
To fix this, I added optional chaining (`?.`) to safely handle the `undefined` case.